### PR TITLE
[39기 박문영] Router :Outlet 사용하여  헤더푸터 포함 MainLayout 추가 적용

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import Header from './components/Header/Header';
-import Footer from './components/Footer/Footer';
+import MainLayout from './routerLayout/MainLayout';
 import Main from './pages/Main/Main';
 import Signin from './pages/Signin/Signin';
 import Signup from './pages/Signup/Signup';
@@ -12,16 +11,16 @@ import Projectupload from './pages/Projectupload/Projectupload';
 export default function Router() {
   return (
     <BrowserRouter>
-      <Header />
       <Routes>
-        <Route path="/" element={<Main />} />
+        <Route element={<MainLayout />}>
+          <Route path="/" element={<Main />} />
+          <Route path="/productdetail" element={<Productdetail />} />
+          <Route path="/projectupload" element={<Projectupload />} />
+        </Route>
+        <Route path="/payment" element={<Payment />} />
         <Route path="/signin" element={<Signin />} />
         <Route path="/signup" element={<Signup />} />
-        <Route path="/productdetail/:id" element={<Productdetail />} />
-        <Route path="/payment" element={<Payment />} />
-        <Route path="/projectupload" element={<Projectupload />} />
       </Routes>
-      <Footer />
     </BrowserRouter>
   );
 }

--- a/src/routerLayout/MainLayout.js
+++ b/src/routerLayout/MainLayout.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Header from '../components/Header/Header';
+import Footer from '../components/Footer/Footer';
+import { Outlet } from 'react-router-dom';
+
+export default function MainLayout() {
+  return (
+    <>
+      <Header />
+      <Outlet />
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 헤더푸터가 포함된 페이지와 포함하지 않는 페이지의 레이아웃 구분 완료

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 헤더푸터가 포함된 페이지와 포함하지 않는 페이지의 레이아웃 구분
- 기존에 써왔던 방식으로는 라우터의 분리가 안되었다. 
Outlet를 사용하면 라우터를 분리할 수 있다고 들어서 검색 후 적용하여 분리를 하였다. 
우선 MainLayout.js에 

export default function MainLayout() {
  return (
    <>
      <Header />
      <Outlet />
      <Footer />
    </>
  );
}

를 만들고 이를 라우터에 적용하였다; 

<Routes>
   // 헤더푸터 포함 레이아웃
  <Route element={<MainLayout />}>
    <Route path="/" element={<Main />} />
    <Route path="/productdetail" element={<Productdetail />} />
    <Route path="/projectupload" element={<Projectupload />} />
  </Route>
   // 헤더푸터 포함하지않는 레이아웃
  <Route path="/payment" element={<Payment />} />
  <Route path="/signin" element={<Signin />} />
  <Route path="/signup" element={<Signup />} />
</Routes>


