### PR TITLE
[39기 박문영] ADD: 로그인시 헤더 데이터 통신 & 프로젝트 업로드 클릭시 메인으로 화면전환 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@tosspayments/payment-sdk": "^1.2.3",
     "axios": "^1.0.0",
+    "dotenv": "^16.0.3",
     "nodemailer": "^6.8.0",
     "react": "^18.2.0",
     "react-daum-postcode": "^3.1.1",

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,16 +1,33 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 export default function Header() {
   // 로그인 상태
-  const isLogin = localStorage.getItem('token');
+  const isLogin = JSON.parse(localStorage.getItem('token'));
   const navigate = useNavigate();
+
+  const [loginId, setLoginId] = useState('');
 
   function logout() {
     localStorage.removeItem('token');
     navigate('/');
   }
+
+  useEffect(() => {
+    if (isLogin) {
+      fetch(`http://10.58.52.97:3000/user/info`, {
+        headers: {
+          authorization: isLogin,
+        },
+      })
+        .then(response => response.json())
+        .then(result => {
+          console.log(result);
+          setLoginId(result);
+        });
+    }
+  }, []);
 
   return (
     <HeaderWrap>
@@ -30,7 +47,7 @@ export default function Header() {
                 <span>프로젝트 올리기 시작하기</span>
               </BtnUpload>
               <BtnLoginStatus>
-                <span>유저네임</span>
+                <span>{loginId.nickname}</span>
               </BtnLoginStatus>
               <BtnLoginStatus onClick={logout}>
                 <span>로그아웃</span>
@@ -38,7 +55,11 @@ export default function Header() {
             </>
           )}
           {!isLogin && (
-            <BtnLoginStatus>
+            <BtnLoginStatus
+              onClick={() => {
+                navigate('/signin');
+              }}
+            >
               <span>회원가입/로그인</span>
             </BtnLoginStatus>
           )}

--- a/src/pages/Projectupload/Projectupload.js
+++ b/src/pages/Projectupload/Projectupload.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { PROJECT_UPLAOD_LIST } from './ProjectUploadListData';
+import { useNavigate } from 'react-router-dom';
 
 export default function Projectupload() {
   const [imgPreveiw, setImgPreveiw] = useState(null);
@@ -16,6 +17,8 @@ export default function Projectupload() {
     date_start: '',
     date_end: '',
   });
+
+  const navigate = useNavigate();
 
   function inputValueBring(e) {
     const { name, value, id, files } = e.target;
@@ -36,6 +39,7 @@ export default function Projectupload() {
     formData.append('targetValue', JSON.stringify(targetValue));
 
     const accessToken = localStorage.getItem('token');
+    console.log('test');
 
     fetch(`http://10.58.52.97:3000/projects`, {
       method: 'POST',
@@ -44,10 +48,12 @@ export default function Projectupload() {
         //'Content-Type': 'multipart/form-data',
 
         // 토큰 전달
-        authorization: accessToken,
+        authorization: JSON.parse(accessToken),
       },
       body: formData,
     });
+
+    navigate('/');
   }
 
   // 이미지 미리보기


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 로그인 후 헤더에 유저 닉네임 데이터 추가 & 프로젝트올리기 -> 데이터입력후 클릭시 화면전환 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 로그인 후 헤더에 유저 닉네임 데이터 추가 & 프로젝트올리기 -> 데이터입력후 클릭시 화면전환 추가 완료

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
  useEffect(() => {
    if (isLogin) {
      fetch(`http://10.58.52.97:3000/user/info`, {
        headers: {
          authorization: isLogin,
        },
      })
        .then(response => response.json())
        .then(result => {
          console.log(result);
          setLoginId(result);
        });
    }
  }, []);

fetch 함수는 백에 데이터를 전송하거나, 받거나 둘 중 하나만 가능한줄 알았는데 
둘 다 동시에 가능하다고 전달받아 시행해보니 적용되었다...
fetch함수에 대해서 좀 더 알아봐야겠다 모르고 쓰니 아무것도 모르겠다...


